### PR TITLE
Disable save-position-on-quit for files that qualify for looping

### DIFF
--- a/autoloop.lua
+++ b/autoloop.lua
@@ -2,6 +2,7 @@
 -- Automatically set loop-file=inf for duration <= given length. Default is 5s
 -- Use autoloop_duration=n in script-opts/autoloop.conf to set your preferred length
 -- Alternatively use script-opts=autoloop-autoloop_duration=n in mpv.conf (takes priority)
+-- Also disables the save-position-on-quit for this file, if it qualifies for looping.
 
 
 require 'mp.options'
@@ -42,6 +43,7 @@ function set_loop()
     -- Loops file if was_loop is false, and file meets requirements
     if not was_loop and duration <= autoloop_duration then
         mp.set_property_native("loop-file", true)
+        mp.command("no-osd set file-local-options/save-position-on-quit no")
         -- Unloops file if was_loop is true, and file does not meet requirements
     elseif was_loop and duration > autoloop_duration then
         mp.set_property_native("loop-file", false)

--- a/autoloop.lua
+++ b/autoloop.lua
@@ -43,7 +43,7 @@ function set_loop()
     -- Loops file if was_loop is false, and file meets requirements
     if not was_loop and duration <= autoloop_duration then
         mp.set_property_native("loop-file", true)
-        mp.command("no-osd set file-local-options/save-position-on-quit no")
+        mp.set_property_bool("file-local-options/save-position-on-quit", false)
         -- Unloops file if was_loop is true, and file does not meet requirements
     elseif was_loop and duration > autoloop_duration then
         mp.set_property_native("loop-file", false)


### PR DESCRIPTION
Thanks for the script! One issue I've had was that short files that qualified for looping would be harder to close without leaving a file in watch_later (as a result of having `save-position-on-quit` enabled), since the file in watch_later is only deleted if the end of the file is reached.

 This disables it. (Thanks to @CogentRedTester)